### PR TITLE
updated online course and tools of trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ And don't forget to **bookmark AWS Security bulletin** for new vulnerabilities n
 9. [Learning Path for AWS Security](https://learn.acloud.guru/learning-path/aws-security) - Nicely designed the learning path who wants to be an AWS Security Experts from Acloud.guru
 10. [Cloud Hacking course](https://www.notsosecure.com/hacking-training/cloud-hacking/) - From NotSoSercure
 11. [Breaking and Pwning Apps and Servers in AWS and Azure](https://github.com/appsecco/breaking-and-pwning-apps-and-servers-aws-azure-training) - Previously an instructor led training now released as free and open source courseware for Cloud Pentesters
+12. [AWS Security Learning Plan](https://explore.skillbuilder.aws/learn/public/learning_plan/view/91/security-learning-plan) - AWS Structured Security learning plan with free structured course.
 
 ## Tools of Trade
 1. [AWS Security Products - Official](https://aws.amazon.com/products/security/) - Few Important tools that you should consider are:
@@ -155,6 +156,8 @@ And don't forget to **bookmark AWS Security bulletin** for new vulnerabilities n
 14. [Cloud Mapper](https://github.com/duo-labs/cloudmapper) - Analyze your AWS environments (Python)
 15. [ConsoleMe](https://github.com/Netflix/consoleme) - A Central Control Plane for AWS Permissions and Access
 16. [AWS Firewall Factory](https://github.com/globaldatanet/aws-firewall-factory) - Deploy, update, and stage your WAFs while managing them centrally via FMS.
+17. [AWS Pentesting/Red Team Methodology - by hacktricks](https://cloud.hacktricks.xyz/pentesting-cloud/aws-pentesting) - A Collection for AWS environment penetration testing methodology.
+18. [AWS Pentesting/Red Team Methodology - by hackingthe.cloud](https://hackingthe.cloud/aws/general-knowledge/aws_organizations_defaults/) - A collection of attacks/tactics/techniques that can use by offensive security professionals during cloud exploitation.
 
 ## Security Practices and CTFs
 1. [AWS Well Architected Security Labs](https://wellarchitectedlabs.com/security/)


### PR DESCRIPTION
Hi Jassics,

I have added the below changes

1. online courses
[AWS Security Learning Plan](https://explore.skillbuilder.aws/learn/public/learning_plan/view/91/security-learning-plan)

2. tools of trade
[AWS Pentesting/Red Team Methodology - by hacktricks](https://cloud.hacktricks.xyz/pentesting-cloud/aws-pentesting) - A Collection for AWS environment penetration testing methodology.
[AWS Pentesting/Red Team Methodology - by hackingthe.cloud](https://hackingthe.cloud/aws/general-knowledge/aws_organizations_defaults/) - A collection of attacks/tactics/techniques that can use by offensive security professionals during cloud exploitation.
Please accept my pull request.

Thanks,
Naveen raj