### PR TITLE
Add boto3-refresh-session to security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ And don't forget to **bookmark AWS Security bulletin** for new vulnerabilities n
 22. [Nubicustos](https://github.com/Su1ph3r/Nubicustos) - Orchestrates 20+ security tools (Prowler, ScoutSuite, Checkov, CloudFox, Pacu, etc.) with unified findings, attack paths, and compliance
 23. [CloudSecure](https://github.com/carlosinfantes/cloudsecure) - Open-source AWS security assessment platform with AI-powered analysis, Prowler integration, and automated CIS benchmark scanning. Built serverless with CDK, Lambda, and Step Functions
 23. [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - Open-source AWS security scanner that detects attack chains and generates remediation code. 80+ checks, CIS/SOC 2 compliance.
+24. [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) - A simple Python package for refreshing AWS temporary credentials in boto3 automatically. Supports MFA, IoT, and custom auth flows.
 
 ## Security Practices and CTFs
 1. [AWS Well Architected Security Labs](https://wellarchitectedlabs.com/security/)


### PR DESCRIPTION
The following PR follows up on [this GitHub issue](https://github.com/jassics/awesome-aws-security/issues/26).

The contents of the following PR were copied and pasted from the above PR (link in the GitHub issue).

--------------------

Hello!

I would like to add [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) to this repository.

`boto3-refresh-session` is an intuitive Python package for refreshing the temporary security credentials in a `boto3.session.Session` object automatically. It has approximately **205K downloads on PyPI**, and it has been featured in [tl;dr sec](https://tldrsec.com/p/tldr-sec-282) and [Cloud Sec List](https://cloudseclist.com/issues/issue-290). The overwhelming majority of downloads are from Linux systems, suggesting the package is part of many CI-CD systems globally. Although I am not at liberty to explicitly name my users, this package is used by the Cyber Security team at a FAANG company, the genetics department of a prestigious university in the United States, and many mid-size companies.

`boto3-refresh-session` has the following features:

- Drop-in replacement for `boto3.session.Session`
- MFA support included for STS
- Supports automatic temporary credential refresh for: 
  - **STS**
  - **IoT Core** 
    - X.509 certificates w/ role aliases over mTLS (PEM files and PKCS#11)
    - MQTT actions are available!
  - Custom authentication methods

`boto3-refresh-session` exists primarily to address edge-cases where `credential_process` falls short, IOT development, and local development, among countless other scenarios. 

I believe including `boto3-refresh-session` on this README would benefit your readers greatly!