### PR TITLE
Add Guardrail for AWS Console to Tools of Trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ And don't forget to **bookmark AWS Security bulletin** for new vulnerabilities n
 23. [CloudSecure](https://github.com/carlosinfantes/cloudsecure) - Open-source AWS security assessment platform with AI-powered analysis, Prowler integration, and automated CIS benchmark scanning. Built serverless with CDK, Lambda, and Step Functions
 23. [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - Open-source AWS security scanner that detects attack chains and generates remediation code. 80+ checks, CIS/SOC 2 compliance.
 24. [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) - A simple Python package for refreshing AWS temporary credentials in boto3 automatically. Supports MFA, IoT, and custom auth flows.
+25. [Guardrail for AWS Console](https://github.com/codedigital-software/guardrail-aws) - Browser extension that intercepts destructive AWS Console actions (Terminate instance, Delete bucket/DB/function) and security-group rules opening 0.0.0.0/0, showing an account-aware confirmation before the click goes through. Client-side only, no network requests, MIT.
 
 ## Security Practices and CTFs
 1. [AWS Well Architected Security Labs](https://wellarchitectedlabs.com/security/)


### PR DESCRIPTION
Adds a free/MIT browser extension that adds click-time confirmation for destructive AWS Console actions, naming the account you're acting in. Complements the audit/assessment tools already listed by covering the human-error vector at the moment of the click rather than after the fact.

- Source: https://github.com/codedigital-software/guardrail-aws
- Client-side only: no backend, no telemetry, zero network requests; permissions are `storage` + Console origins.

Appended at the end of **Tools of Trade** per `Contribute.md`; checked it isn't a duplicate.