### PR TITLE
Add Nuberio Audit to Tools of Trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ And don't forget to **bookmark AWS Security bulletin** for new vulnerabilities n
 23. [CloudSecure](https://github.com/carlosinfantes/cloudsecure) - Open-source AWS security assessment platform with AI-powered analysis, Prowler integration, and automated CIS benchmark scanning. Built serverless with CDK, Lambda, and Step Functions
 23. [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - Open-source AWS security scanner that detects attack chains and generates remediation code. 80+ checks, CIS/SOC 2 compliance.
 24. [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) - A simple Python package for refreshing AWS temporary credentials in boto3 automatically. Supports MFA, IoT, and custom auth flows.
+25. [Nuberio Audit](https://www.nuberio.com/audit) - Free, read-only AWS account scan for missing/noisy CloudWatch alarms, GuardDuty/Security Hub findings, and AWS Config compliance gaps (free tool, not open source)
 
 ## Security Practices and CTFs
 1. [AWS Well Architected Security Labs](https://wellarchitectedlabs.com/security/)


### PR DESCRIPTION
Adds Nuberio Audit as item 25 under "Tools of Trade."

What it does: read-only AWS account scan that checks CloudWatch alarm coverage (missing alarms on RDS/Lambda/ECS/ALB/etc.), classifies existing alarms as noisy/dead/healthy, and surfaces GuardDuty, Security Hub, and Config findings in one report. Connects via a reviewable CloudFormation template (read-only IAM role), no access keys required.

Full transparency: this is a free tool, not open-source — most of this section links to OSS repos, so flagging that upfront in case it's out of scope; happy to close if so.