### PR TITLE
Add aws-google-oidc to Tools of Trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ And don't forget to **bookmark AWS Security bulletin** for new vulnerabilities n
 23. [CloudSecure](https://github.com/carlosinfantes/cloudsecure) - Open-source AWS security assessment platform with AI-powered analysis, Prowler integration, and automated CIS benchmark scanning. Built serverless with CDK, Lambda, and Step Functions
 23. [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - Open-source AWS security scanner that detects attack chains and generates remediation code. 80+ checks, CIS/SOC 2 compliance.
 24. [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) - A simple Python package for refreshing AWS temporary credentials in boto3 automatically. Supports MFA, IoT, and custom auth flows.
+25. [aws-google-oidc](https://github.com/dialohq/aws-google-oidc) - Uses Google OIDC service-account impersonation to obtain temporary STS credentials through AWS `credential_process`, with secure OS-keychain token caching instead of long-lived AWS keys.
 
 ## Security Practices and CTFs
 1. [AWS Well Architected Security Labs](https://wellarchitectedlabs.com/security/)


### PR DESCRIPTION
Adds an MIT-licensed defensive credential helper.

`aws-google-oidc` exchanges a Google identity token for temporary credentials using `AssumeRoleWithWebIdentity`. It integrates through the standard AWS `credential_process` interface, supports AWS STS and compatible services such as Ceph RGW, and caches the Google token in the operating-system keychain.

Release: https://github.com/dialohq/aws-google-oidc/releases/tag/v0.1.0

Disclosure: I maintain this project.